### PR TITLE
Fix: Incorrect params for extracting error data

### DIFF
--- a/lib/import/import-manager.ts
+++ b/lib/import/import-manager.ts
@@ -117,7 +117,7 @@ export function importManager(config: ImportConfig) {
                         .map((m) => {
                             return {
                                 codename: m.inputItem.codename,
-                                error: extractErrorData(m.state === 'error').message
+                                error: extractErrorData(m.error).message
                             };
                         }),
                     ...importResult.editedAssets
@@ -125,7 +125,7 @@ export function importManager(config: ImportConfig) {
                         .map((m) => {
                             return {
                                 codename: m.inputItem.migrationAsset.codename,
-                                error: extractErrorData(m.state === 'error').message
+                                error: extractErrorData(m.error).message
                             };
                         })
                 ]
@@ -145,7 +145,7 @@ export function importManager(config: ImportConfig) {
                         return {
                             codename: m.inputItem.system.codename,
                             type: m.inputItem.system.type,
-                            error: extractErrorData(m.state === 'error').message
+                            error: extractErrorData(m.error).message
                         };
                     })
             },
@@ -167,7 +167,7 @@ export function importManager(config: ImportConfig) {
                             codename: m.inputItem.system.codename,
                             language: m.inputItem.system.language,
                             type: m.inputItem.system.type,
-                            error: extractErrorData(m.state === 'error').message
+                            error: extractErrorData(m.error).message
                         };
                     })
             }


### PR DESCRIPTION
### Motivation

Currently some errors are not processed correctly and are passing a boolean.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. Attempt to migrate an asset that will result in an error.
2. See that errors now properly report.
